### PR TITLE
remove penis from personal nouns

### DIFF
--- a/data/personal_nouns.json
+++ b/data/personal_nouns.json
@@ -5016,7 +5016,6 @@
     "penelope",
     "peninsula",
     "peninsular",
-    "penis",
     "penitent",
     "penknife",
     "penman",


### PR DESCRIPTION
Can we remove this? Don't think anyone wants this in their randomly generated user name.